### PR TITLE
Add insert_time column to snowflake connector tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>2.4.4</version>
+    <version>2.5.0</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -44,7 +44,7 @@ public class Utils
 {
 
   //Connector version, change every release
-  public static final String VERSION = "2.4.4";
+  public static final String VERSION = "2.5.0";
 
   //connector parameter list
   public static final String NAME = "name";

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -23,6 +23,13 @@ public interface SnowflakeConnectionService
   void createTable(String tableName);
 
   /**
+   * alter table if not compatible
+   *
+   * @param tableName table name
+   */
+  void alterTable(String tableName);
+
+  /**
    * create a snowpipe
    *
    * @param pipeName  pipe name

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -7,6 +7,7 @@ public interface SnowflakeConnectionService
 {
   /**
    * Create a table with three variant columns: RECORD_METADATA, RECORD_KEY and RECORD_CONTENT
+   * and a timestamp column: INSERT_TIME
    *
    * @param tableName a string represents table name
    * @param overwrite if true, execute "create or replace table" query;

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -89,9 +89,8 @@ public class SnowflakeConnectionServiceV1 extends Logging
   public void alterTable(String tableName) {
     checkConnection();
     InternalUtils.assertNotEmpty("tableName", tableName);
-    // FIXME: SQL have to be idempotent
-    String query = "alter table identifier(?) " +
-            " add column insert_time timestamp default current_timestamp";
+
+    String query = "alter table identifier(?) add column insert_time timestamp";
     try
     {
       PreparedStatement stmt = conn.prepareStatement(query);
@@ -100,11 +99,14 @@ public class SnowflakeConnectionServiceV1 extends Logging
       stmt.close();
     } catch (SQLException e)
     {
-      throw SnowflakeErrors.ERROR_2007.getException(e);
+      // checking column exists if the method will be populated later
+      if (!"column 'INSERT_TIME' already exists".equals(e.getMessage())) {
+        throw SnowflakeErrors.ERROR_2007.getException(e);
+      }
     }
 
     logInfo("alter table {}", tableName);
-    // getTelemetryClient().reportKafkaCreateTable(tableName);
+    getTelemetryClient().reportKafkaCreateTable(tableName);
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -55,14 +55,12 @@ public class SnowflakeConnectionServiceV1 extends Logging
     if (overwrite)
     {
       query = "create or replace table identifier(?) (record_metadata " +
-        "variant, record_key variant, record_content variant, " +
-        "insert_time timestamp default current_timestamp)";
+        "variant, record_key variant, record_content variant, insert_time timestamp)";
     }
     else
     {
       query = "create table if not exists identifier(?) (record_metadata " +
-        "variant, record_key variant, record_content variant, " +
-        "insert_time timestamp default current_timestamp)";
+        "variant, record_key variant, record_content variant, insert_time timestamp)";
     }
     try
     {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -103,7 +103,7 @@ public class SnowflakeConnectionServiceV1 extends Logging
     {
       // alter table should be idempotent to prevent errors
       // if there will be another alters statements
-      if (!"column 'INSERT_TIME' already exists".equals(e.getMessage())) {
+      if (e.getMessage() == null || !e.getMessage().contains("column 'INSERT_TIME' already exists")) {
         throw SnowflakeErrors.ERROR_2007.getException(e);
       }
     }
@@ -348,7 +348,7 @@ public class SnowflakeConnectionServiceV1 extends Logging
             }
             break;
           case "INSERT_TIME":
-            if(result.getString(2).equals("TIMESTAMP"))
+            if(result.getString(2).equals("TIMESTAMP_NTZ(9)"))
             {
               hasInsertTime = true;
             }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -55,12 +55,14 @@ public class SnowflakeConnectionServiceV1 extends Logging
     if (overwrite)
     {
       query = "create or replace table identifier(?) (record_metadata " +
-        "variant, record_key variant, record_content variant)";
+        "variant, record_key variant, record_content variant, " +
+        "insert_time timestamp default current_timestamp)";
     }
     else
     {
       query = "create table if not exists identifier(?) (record_metadata " +
-        "variant, record_key variant, record_content variant)";
+        "variant, record_key variant, record_content variant, " +
+        "insert_time timestamp default current_timestamp)";
     }
     try
     {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -807,7 +807,8 @@ public class SnowflakeConnectionServiceV1 extends Logging
   private String pipeDefinition(String tableName, String stageName)
   {
     return "copy into " + tableName +
-      "(RECORD_METADATA, RECORD_KEY, RECORD_CONTENT) from (select $1:meta, $1:key, $1:content from"
+      "(RECORD_METADATA, RECORD_KEY, RECORD_CONTENT, INSERT_TIME)"
+      + " from (select $1:meta, $1:key, $1:content, current_timestamp() from"
       + " @" + stageName + " t) file_format = (type = 'json')";
 
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -801,7 +801,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService
       {
         boolean compatible = false; // true - if table compatible
         boolean modified = false; // true - if table modified/altered
-        while(!compatible || !modified) {
+        while(!compatible) {
           if (conn.isTableCompatible(tableName))
           {
             logInfo("Using existing table {}.", tableName);

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -799,19 +799,19 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService
       //create table if not exists
       if (conn.tableExist(tableName))
       {
-        boolean compatible = false;
-        boolean updated = false;
-        while(!compatible || !updated) {
+        boolean compatible = false; // true - if table compatible
+        boolean modified = false; // true - if table modified/altered
+        while(!compatible || !modified) {
           if (conn.isTableCompatible(tableName))
           {
             logInfo("Using existing table {}.", tableName);
             telemetryService.reportKafkaReuseTable(tableName);
             compatible = true;
           }
-          else if (!updated)
+          else if (!modified)
           {
             conn.alterTable(tableName);
-            updated = true;
+            modified = true;
           }
           else
           {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -762,10 +762,10 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService
       {
         if (!conn.isPipeCompatible(tableName, stageName, pipeName))
         {
-          throw SnowflakeErrors.ERROR_5005.getException("pipe name: " + pipeName,
-            conn.getTelemetryClient());
+          conn.createPipe(tableName, stageName, pipeName, true);
+        } else {
+          logInfo("pipe {}, recovered from existing pipe", pipeName);
         }
-        logInfo("pipe {}, recovered from existing pipe", pipeName);
       }
       else
       {

--- a/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
@@ -322,7 +322,7 @@ public class ConnectionServiceIT extends Logging
   {
     TestUtils.executeQuery(
       "create or replace table " + tableName +
-      "(record_content variant, record_metadata variant, record_key variant, insert_time timestamp default current_timestamp, other int)"
+      "(record_content variant, record_metadata variant, record_key variant, insert_time timestamp, other int)"
     );
     assert conn.isTableCompatible(tableName);
 
@@ -339,7 +339,7 @@ public class ConnectionServiceIT extends Logging
 
     TestUtils.executeQuery(
       "create or replace table " + tableName +
-      "(record_content variant, record_metadata variant, record_key variant, insert_time timestamp default current_timestamp, other int not null)"
+      "(record_content variant, record_metadata variant, record_key variant, insert_time timestamp, other int not null)"
     );
     assert !conn.isTableCompatible(tableName);
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -29,10 +29,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Random;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -221,6 +218,42 @@ public class TestUtils
     String query = "select * from " + tableName;
 
     return executeQuery(query);
+  }
+
+  /**
+   * describe a table
+   */
+  static ResultSet descTable(String tableName)
+  {
+    String query = "desc table " + tableName;
+
+    return executeQuery(query);
+  }
+
+  /**
+   *
+   * @param tableName
+   * @return Map of column names to list containing name, type, kind, null, default column parameters
+   */
+  static Map<String, ArrayList<String>> descTableCols(String tableName)
+  {
+    ResultSet result = descTable(tableName);
+    Map<String, ArrayList<String>> Columns = new HashMap<>();
+    try
+    {
+      while(result.next()) {
+        ArrayList<String> row = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+          row.add(result.getString(i));
+        }
+        Columns.put(result.getString(1), row);
+      }
+    }
+    catch (Exception e)
+    {
+      throw new RuntimeException(e);
+    }
+    return Columns;
   }
 
   static String getDesRsaKey()


### PR DESCRIPTION
Adds insert_time column with current_timestamp() default. This timestamp represents when snowpipe inserts the row in the destination table to aid in debugging, monitoring/visibility etc.

Due to a snowflake limitation, a column with a default value cannot be added to an existing table, so we leave out the default value for existing tables have the snowpipe specify the timestamp instead.

Snowflake limitation: https://community.snowflake.com/s/question/0D50Z00006uSiEK/syntax-for-adding-a-column-with-currenttimestamp-default-constraint

Test output (skipped FIPSTest)
```
root@6b56f2c332d5:/usr/src/mymaven# mvn test
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Snowflake Kafka Connector 2.5.0
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- jacoco-maven-plugin:0.8.2:prepare-agent (pre-unit-test) @ snowflake-kafka-connector ---
[INFO] argLine set to -javaagent:/root/.m2/repository/org/jacoco/org.jacoco.agent/0.8.2/org.jacoco.agent-0.8.2-runtime.jar=destfile=/usr/src/mymaven/target/jacoco-ut.exec
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ snowflake-kafka-connector ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /usr/src/mymaven/src/main/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ snowflake-kafka-connector ---
[INFO] Nothing to compile - all classes are up to date
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ snowflake-kafka-connector ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 4 resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ snowflake-kafka-connector ---
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Compiling 25 source files to /usr/src/mymaven/target/test-classes
[WARNING] /usr/src/mymaven/src/test/java/com/snowflake/kafka/connector/mock/MockResultSetForSizeTest.java: Some input files use or override a deprecated API.
[WARNING] /usr/src/mymaven/src/test/java/com/snowflake/kafka/connector/mock/MockResultSetForSizeTest.java: Recompile with -Xlint:deprecation for details.
[INFO]
[INFO] --- maven-surefire-plugin:2.22.0:test (default-test) @ snowflake-kafka-connector ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.snowflake.kafka.connector.records.RecordContentTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.216 s - in com.snowflake.kafka.connector.records.RecordContentTest
[INFO] Running com.snowflake.kafka.connector.records.MetaColumnTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.844 s - in com.snowflake.kafka.connector.records.MetaColumnTest
[INFO] Running com.snowflake.kafka.connector.records.ValueSchemaTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.snowflake.kafka.connector.records.ValueSchemaTest
[INFO] Running com.snowflake.kafka.connector.records.ConverterTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.239 s - in com.snowflake.kafka.connector.records.ConverterTest
[INFO] Running com.snowflake.kafka.connector.records.HeaderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in com.snowflake.kafka.connector.records.HeaderTest
[INFO] Running com.snowflake.kafka.connector.records.KeyColumnTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.snowflake.kafka.connector.records.KeyColumnTest
[INFO] Running com.snowflake.kafka.connector.records.ProcessRecordTest
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.203 s - in com.snowflake.kafka.connector.records.ProcessRecordTest
[INFO] Running com.snowflake.kafka.connector.ConnectorTest
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.819 s - in com.snowflake.kafka.connector.ConnectorTest
[INFO] Running com.snowflake.kafka.connector.UtilsTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.129 s - in com.snowflake.kafka.connector.UtilsTest
[INFO] Running com.snowflake.kafka.connector.SecurityTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.245 s - in com.snowflake.kafka.connector.SecurityTest
[INFO] Running com.snowflake.kafka.connector.internal.InternalUtilsTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.155 s - in com.snowflake.kafka.connector.internal.InternalUtilsTest
[INFO] Running com.snowflake.kafka.connector.internal.FIPSTest
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 s - in com.snowflake.kafka.connector.internal.FIPSTest
[INFO] Running com.snowflake.kafka.connector.internal.FileNameUtilsTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in com.snowflake.kafka.connector.internal.FileNameUtilsTest
[INFO] Running com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1Test
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.322 s - in com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1Test
[INFO] Running com.snowflake.kafka.connector.internal.LoggingTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.snowflake.kafka.connector.internal.LoggingTest
[INFO] Running com.snowflake.kafka.connector.internal.SnowflakeURLTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in com.snowflake.kafka.connector.internal.SnowflakeURLTest
[INFO] Running com.snowflake.kafka.connector.ConnectorConfigTest
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in com.snowflake.kafka.connector.ConnectorConfigTest
[INFO] Running com.snowflake.kafka.connector.SinkTaskTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 67.632 s - in com.snowflake.kafka.connector.SinkTaskTest
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 93, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO]
[INFO] --- jacoco-maven-plugin:0.8.2:report (post-unit-test) @ snowflake-kafka-connector ---
[INFO] Loading execution data file /usr/src/mymaven/target/jacoco-ut.exec
[INFO] Analyzed bundle 'Snowflake Kafka Connector' with 38 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:54 min
[INFO] Finished at: 2020-12-04T18:32:32+00:00
[INFO] Final Memory: 34M/341M
[INFO] ------------------------------------------------------------------------
```